### PR TITLE
py3.12 support

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-pocketsphinx~=0.1
+pocketsphinx~=5.0
 ovos-plugin-manager>=0.0.1
 phoneme_guesser~=0.1.1
 SpeechRecognition>=3.8.1


### PR DESCRIPTION
allows the plugin to install. but we need to figure out
```
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]: 2024-03-15 17:24:48.631 - voice - ovos_plugin_manager.wakewords:load_module:165 - INFO - Loading "wake_up" wake word via ovos-ww-plugin-pocketsphinx with config: {'module': 'ovos-ww-plugin-pocketsphinx', 'phonemes': 'W EY K . AH P', 'threshold': 1e-20, 'lang': 'en-us', 'wakeup': True, 'fallback_ww': 'wake_up_vosk'}
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]: 2024-03-15 17:24:48.641 - voice - ovos_plugin_manager.wakewords:load_module:172 - INFO - Loaded the Wake Word wake_up with module ovos-ww-plugin-pocketsphinx
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]: ERROR: "ps_config.c", line 158: Only one of lm, jsgf, fsg, keyphrase, kws, allphone, lmctl, can be enabled at a time in config
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]: 2024-03-15 17:24:48.642 - voice - ovos_plugin_manager.wakewords:create_hotword:196 - ERROR - Failed to load hotword: wake_up - ovos-ww-plugin-pocketsphinx
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]: 2024-03-15 17:24:48.642 - voice - ovos_plugin_manager.wakewords:create_hotword:197 - ERROR - Failed to initialize PocketSphinx
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]: Traceback (most recent call last):
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/wakewords.py", line 194, in create_hotword
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]:     return cls.load_module(module, hotword, ww_config, lang, loop)
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/wakewords.py", line 173, in load_module
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]:     return clazz(hotword, hotword_config, lang=lang)
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_ww_plugin_pocketsphinx/__init__.py", line 54, in __init__
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]:     self.decoder = Decoder(config)
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]:                    ^^^^^^^^^^^^^^^
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]:   File "_pocketsphinx.pyx", line 852, in _pocketsphinx.Decoder.__init__
Mar 15 17:24:48 rpi5b03 ovos-dinkum-listener[82281]: RuntimeError: Failed to initialize PocketSphinx

```

no migration guide, just this https://cmusphinx.github.io/2022/09/release-candidate-4/ 

> Python code is entirely unaffected by these changes 

obviously not the case :upside_down_face: 

related https://github.com/cmusphinx/pocketsphinx/issues/386